### PR TITLE
商品詳細ページ、商品確認ページのサーバーサイド実装

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -9,7 +9,6 @@
 //
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
-//= require turbolinks
 //= require jquery
 //= require rails-ujs
 //= require activestorage

--- a/app/assets/javascripts/category.js
+++ b/app/assets/javascripts/category.js
@@ -22,7 +22,7 @@ $(function(){
     var grandchildSelectHtml = '';
     grandchildSelectHtml = `<div class='seller__in__genre__input__added' id= 'grandchildren_input'>
                               <div class='seller__in__genre__input__box'>
-                                <select class="seller__in__genre__input__box--select" id="grandchild_category">
+                                <select class="seller__in__genre__input__box--select" id="grandchild_category" name="category_id">
                                   <option value="---" data-category="---">---</option>
                                   ${insertHTML}
                                 </select>
@@ -32,6 +32,7 @@ $(function(){
   }
   // 親カテゴリー選択後のイベント
   $('#parent_category').on('change', function(){
+
     var parentCategory = document.getElementById('parent_category').value; //選択された親カテゴリーの名前を取得
     // $('#parent_category option:selected').val();
     if (parentCategory != "---"){ //親カテゴリーが初期値でないことを確認

--- a/app/assets/javascripts/category.js
+++ b/app/assets/javascripts/category.js
@@ -22,7 +22,7 @@ $(function(){
     var grandchildSelectHtml = '';
     grandchildSelectHtml = `<div class='seller__in__genre__input__added' id= 'grandchildren_input'>
                               <div class='seller__in__genre__input__box'>
-                                <select class="seller__in__genre__input__box--select" id="grandchild_category" name="category_id">
+                                <select class="seller__in__genre__input__box--select" id="grandchild_category" name="item[category_id]">
                                   <option value="---" data-category="---">---</option>
                                   ${insertHTML}
                                 </select>

--- a/app/assets/stylesheets/modules/_show.scss
+++ b/app/assets/stylesheets/modules/_show.scss
@@ -25,9 +25,9 @@
     .breadcrumbs__text:hover {
       color: #3ccace;
       
-   }        
+    }        
   }
- }
+  }
 }
 
 .mainProduct {
@@ -97,8 +97,8 @@
             font-weight: bold;
         }
         
+        
           .details {
-
         }
       }
         &__introduction {
@@ -275,4 +275,44 @@
       }
     }
   }
+  .buy-link-box{
+    height: 50px;
+    width:  100%;
+    background-color: #3ccace;
+    margin-top: 30px;
+    text-align: center;
+    line-height: 50px;
+    margin-bottom: 15px;
+
+    a {
+      text-decoration: none;
+      color: white;
+      }
   }
+  .items-show-button__edit {
+    height: 50px;
+    width:  100%;
+    background-color: #00b0ff;
+    margin-top: 30px;
+    text-align: center;
+    line-height: 50px;
+    margin-bottom: 15px;
+  a {
+    text-decoration: none;
+    color: white;
+    }
+  }
+  .items-show-button__cancel {
+    height: 50px;
+    width:  100%;
+    background-color: #00b0ff;
+    margin-top: 30px;
+    text-align: center;
+    line-height: 50px;
+    margin-bottom: 15px;
+  a {
+    text-decoration: none;
+    color: white;
+    }
+  }
+}

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -15,6 +15,7 @@ class ItemsController < ApplicationController
   end
 
   def confirm
+    @item = Item.find(params[:id])
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -24,6 +24,9 @@ class ItemsController < ApplicationController
       @item.item_images.build
       #セレクトボックスの初期値設定
       @category_parent_array = ["---"]
+      Category.where(ancestry: nil).each do |parent|
+      @category_parent_array << parent.name
+    end
     else
       redirect_to onestep_users_path
     end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -4,7 +4,11 @@ class ItemsController < ApplicationController
   end
   
   def show
-    # @item = Item.find(params[:id])
+    @item = Item.find(params[:id])
+    @category_id = @item.category_id
+    @category_parent = Category.find(@category_id).parent.parent
+    @category_child = Category.find(@category_id).parent
+    @category_grandchild = Category.find(@category_id)
   end
 
   def edit

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-before_action :set_item,only: [:show,:confirm]
+  before_action :set_item,only: [:show,:confirm]
   def index
     #@items = Item.all
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,10 +1,10 @@
 class ItemsController < ApplicationController
-    def index
+before_action :set_item,only: [:show,:confirm]
+  def index
     #@items = Item.all
   end
   
   def show
-    @item = Item.find(params[:id])
     @category_id = @item.category_id
     @category_parent = Category.find(@category_id).parent.parent
     @category_child = Category.find(@category_id).parent
@@ -15,7 +15,6 @@ class ItemsController < ApplicationController
   end
 
   def confirm
-    @item = Item.find(params[:id])
   end
 
   def new
@@ -53,6 +52,10 @@ class ItemsController < ApplicationController
   end
 
   private
+  def set_item
+    @item = Item.find(params[:id])
+  end
+
   def item_params
     params.require(:item).permit(
       :name, 

--- a/app/views/items/_exhibit-btn.html.haml
+++ b/app/views/items/_exhibit-btn.html.haml
@@ -1,4 +1,4 @@
 .exhibit_button
-  = link_to image_tag("icon_camera.png", class:"exhibit_button_a"), "/items/new"
+  = link_to image_tag("icon_camera.png", class:"exhibit_button_a"), new_item_path
   .exhibit_button__text
     出品する

--- a/app/views/items/_main.html.haml
+++ b/app/views/items/_main.html.haml
@@ -100,6 +100,7 @@
       .main__pickupC__productBox__productlists
         .main__pickupC__productBox__productlists__list
           .main__pickupC__productBox__productlists__list__picture
+          -# 以下のpath指定は仮置きのため、一覧表示の際に修正必要
           = link_to image_tag("a001.png", class:"pic"), "/items/1"
           .main__pickupC__productBox__productlists__list__text
             text

--- a/app/views/items/_main.html.haml
+++ b/app/views/items/_main.html.haml
@@ -100,7 +100,7 @@
       .main__pickupC__productBox__productlists
         .main__pickupC__productBox__productlists__list
           .main__pickupC__productBox__productlists__list__picture
-          = image_tag("a001.png", class:"pic")
+          = link_to image_tag("a001.png", class:"pic"), "/items/1"
           .main__pickupC__productBox__productlists__list__text
             text
         .main__pickupC__productBox__productlists__list
@@ -119,7 +119,7 @@
       ピックアップカテゴリー
     .main__pickupC__productBox
       .main__pickupC__productBox__producthead
-        = link_to "#" do
+        = link_to "" do
           アーカイブ
       .main__pickupC__productBox__productlists
         .main__pickupC__productBox__productlists__list

--- a/app/views/items/confirm.html.haml
+++ b/app/views/items/confirm.html.haml
@@ -18,12 +18,14 @@
           .confirm__main__field__items__item__area
             .confirm__main__field__items__item__area__box
               .confirm-itemImage
-                = image_tag 'a007.png'
+                = image_tag @item.item_images[0].item_image.url
                 .confirm__itemText
                   .confirm-itemName
-                    product3
+                    = @item.name
                   .confirm-itemPrice
-                    ¥30,000 (税込) 送料込み
+                    ¥
+                    = @item.price
+                    = @item.delivery_price.delivery_price
 
         .confirm__main__field__items__price
           .confirm__main__field__items__price__area
@@ -32,7 +34,8 @@
                 %li.price-title
                   支払い金額
                 %li.price-amount
-                  ¥30,000
+                  ¥
+                  = @item.price
               .price-point
                 = check_box_tag :check1
                 = label_tag :check1, "ポイントを使用(所持ポイント:P0)", class: "check-text"

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -7,7 +7,7 @@
   %ul.details__breadcrumbs__text
     %li.text__category
       = link_to "#", class: "breadcrumbs__text" do
-        HURIMA
+        FURIMA
     %li.text__category
       = icon('fas', 'angle-right')
     %li.text__category
@@ -104,6 +104,20 @@
                   発送日の目安
                 %td.table-right
                   = @item.delivery_day.delivery_day
+
+          - if user_signed_in? && @item.seller_id == current_user.id
+            .items-show-button__edit
+              = link_to '編集する', "#"
+            .items-show-button__cancel
+              = link_to '出品を取り消す', "#"
+
+          - else
+            .buy-link-box
+              - if user_signed_in?
+                = link_to '購入確認画面へ', "#"
+              - else
+                = link_to "ログイン" ,new_user_session_path
+          
         
         .mainProduct__content__top__items__optional
           %ul.optional

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -114,7 +114,7 @@
           - else
             .buy-link-box
               - if user_signed_in?
-                = link_to '購入確認画面へ', "#"
+                = link_to '購入確認画面へ',confirm_item_path
               - else
                 = link_to "ログイン" ,new_user_session_path
           

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -30,27 +30,25 @@
     .mainProduct__content__top
       .mainProduct__content__top__items
         %h2.mainProduct__content__top__items__name
-          product3
+          = @item.name
         .mainProduct__content__top__items__image
-          = image_tag 'a007.png', class: "big"
+          = image_tag @item.item_images[0].item_image.url, class:"big"
         %ul.mainProduct__content__top__items__images
-          %li
-            = image_tag 'a007.png', class: "small"
-          %li
-            = image_tag 'a001.png', class: "small"
-          %li
-            = image_tag 'a004.png', class: "small"
-        
+          - @item.item_images.each do |image|
+            %li
+              = image_tag image.item_image.url, :width => "75", :height => "75",class:"small"
+            %li
         .mainProduct__content__top__items__price
           .amount
-            ¥30000
+            ¥
+            = @item.price
           %span.details
             （税込）
           %span.details
-            送料込み
+            = @item.delivery_price.delivery_price
         
         .mainProduct__content__top__items__introduction
-          親譲りの無鉄砲で小供の時から損ばかりしている。小学校に居る時分学校の二階から飛び降りて一週間ほど腰を抜かした事がある。なぜそんな無闇をしたと聞く人があるかも知れぬ。別段深い理由でもない。新築の二階から首を出していたら、同級生の一人が冗談に、いくら威張っても、そこから飛び降りる事は出来まい。弱虫やーい。と囃したからである。小使に負ぶさって帰って来た時、おやじが大きな眼をして二階ぐらいから飛び降りて腰
+          = @item.discription
         
         .mainProduct__content__top__items__table
           %table
@@ -59,55 +57,53 @@
                 %th.table-left
                   出品者
                 %td.table-right 
-                  hogehoge  
+                  = @item.seller.nickname
   
               %tr.itemTable2
                 %th.table-left
                   カテゴリー
                 %td.table-right 
-                  %a(href="#")
-                    ベビー・キッズ
-                    %br/
-                  %a(href="#")
-                    ベビー服(男女兼用) ~95cm
-                    %br/
-                  %a(href="#")
-                    アウター
+                  = link_to "#{@category_parent.name}","#"
+                  %br
+                  = link_to "#{@category_child.name}","#"
+                  %br
+                  = link_to "#{@category_grandchild.name}","#"
             
               %tr.itemTable
                 %th.table-left
                   ブランド
                 %td.table-right
-            
+                  = @item.brand.brand
             
               %tr.itemTable
                 %th.table-left
                   商品のサイズ
                 %td.table-right
+                  = @item.size.size
             
               %tr.itemTable
                 %th.table-left
                   商品の状態
                 %td.table-right
-                  未使用に近い
+                  = @item.condition.condition
                     
               %tr.itemTable
                 %th.table-left
                   配送料の負担
                 %td.table-right
-                  送料込み（出品者負担）
+                  = @item.delivery_price.delivery_price
                 
               %tr.itemTable
                 %th.table-left
                   発送元の地域
                 %td.table-right
-                  岩手県
+                  = @item.delivery_area.delivery_area
                     
               %tr.itemTable
                 %th.table-left
                   発送日の目安
                 %td.table-right
-                  4-7日で発送
+                  = @item.delivery_day.delivery_day
         
         .mainProduct__content__top__items__optional
           %ul.optional


### PR DESCRIPTION
# what
商品の詳細ページのサーバサイドと商品確認画面のサーバーサイドの実装

# why
今まで見た目の部分しかできておらず、実際にDBに入っている
商品の情報が表示されていなかったため