### PR TITLE
パンくずリスト実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,3 +83,4 @@ gem 'ancestry'
 gem 'jquery-rails'
 gem 'carrierwave'
 gem 'mini_magick'
+gem "gretel"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,6 +117,8 @@ GEM
       sassc (>= 1.11)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    gretel (3.0.9)
+      rails (>= 3.1.0)
     haml (5.1.2)
       temple (>= 0.8.0)
       tilt
@@ -312,6 +314,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   devise
   font-awesome-sass
+  gretel
   haml-rails (~> 2.0)
   jbuilder (~> 2.5)
   jquery-rails

--- a/app/assets/stylesheets/modules/_breadcrumbs.scss
+++ b/app/assets/stylesheets/modules/_breadcrumbs.scss
@@ -1,6 +1,6 @@
 .breadcrumbs {
   background-color:#fff;
-  padding: 0 200px;
+  padding: 0 150px;
   height: 50px;
   line-height: 50px;
   font-size: 14px;

--- a/app/assets/stylesheets/modules/_breadcrumbs.scss
+++ b/app/assets/stylesheets/modules/_breadcrumbs.scss
@@ -4,4 +4,9 @@
   height: 50px;
   line-height: 50px;
   font-size: 14px;
+
+  a {
+    text-decoration: none;
+    color: #3CCACE;
+  }
 }

--- a/app/views/items/_bread-crumbs.html.haml
+++ b/app/views/items/_bread-crumbs.html.haml
@@ -1,2 +1,2 @@
 .breadcrumbs 
-  メルカリ　＞　マイページ（パンくず実装時に修正）
+  = breadcrumbs pretext: "",separator: " &rsaquo; ", class: "breadcrumbs-list"

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -4,25 +4,8 @@
 
 -# 商品詳細ページ
 .details__breadcrumbs
-  %ul.details__breadcrumbs__text
-    %li.text__category
-      = link_to "#", class: "breadcrumbs__text" do
-        FURIMA
-    %li.text__category
-      = icon('fas', 'angle-right')
-    %li.text__category
-      = link_to "#", class: "breadcrumbs__text" do
-        ベビー・キッズ 
-    %li.text__category
-      = icon('fas', 'angle-right')
-    %li.text__category
-      = link_to "#", class: "breadcrumbs__text" do
-        ベビー服(男女兼用)~95cmアウター
-    %li.text__category
-      = icon('fas', 'angle-right')
-    %li.text__category
-      = link_to "#", class: "breadcrumbs__text" do
-        product3
+  - breadcrumb :show
+  = render "/items/bread-crumbs"
 
 -# 商品詳細メインコンテンツ
 .mainProduct

--- a/app/views/users/_mypage.html.haml
+++ b/app/views/users/_mypage.html.haml
@@ -2,8 +2,8 @@
   .mypage__header
     = render "/items/header"
   .mypage__breadcrumbs
-    - breadcrumb :user, user
-    = breadcrumbs pretext: "",separator: " &rsaquo; ", class: "breadcrumbs-list"
+    - breadcrumb :user, @user
+    = render "/items/bread-crumbs"
   .mypage__main
     .clearfix
       .mypage__main__content

--- a/app/views/users/_mypage.html.haml
+++ b/app/views/users/_mypage.html.haml
@@ -2,7 +2,8 @@
   .mypage__header
     = render "/items/header"
   .mypage__breadcrumbs
-    = render "/items/bread-crumbs"
+    - breadcrumb :user, @user
+    = render "items/bread-crumbs"
   .mypage__main
     .clearfix
       .mypage__main__content

--- a/app/views/users/_mypage.html.haml
+++ b/app/views/users/_mypage.html.haml
@@ -2,8 +2,8 @@
   .mypage__header
     = render "/items/header"
   .mypage__breadcrumbs
-    - breadcrumb :user, @user
-    = render "items/bread-crumbs"
+    - breadcrumb :user, user
+    = breadcrumbs pretext: "",separator: " &rsaquo; ", class: "breadcrumbs-list"
   .mypage__main
     .clearfix
       .mypage__main__content

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,0 +1,35 @@
+# ルート
+crumb :root do
+  link "トップページ", root_path
+end
+
+# マイページ
+crumb :user do
+  link "マイページ", users_path
+  parent :root
+end
+
+# crumb :projects do
+#   link "Projects", projects_path
+# end
+
+# crumb :project do |project|
+#   link project.name, project_path(project)
+#   parent :projects
+# end
+
+# crumb :project_issues do |project|
+#   link "Issues", project_issues_path(project)
+#   parent :project, project
+# end
+
+# crumb :issue do |issue|
+#   link issue.title, issue_path(issue)
+#   parent :project_issues, issue.project
+# end
+
+# If you want to split your breadcrumbs configuration over multiple files, you
+# can create a folder named `config/breadcrumbs` and put your configuration
+# files there. All *.rb files (e.g. `frontend.rb` or `products.rb`) in that
+# folder are loaded and reloaded automatically when you change them, just like
+# this file (`config/breadcrumbs.rb`).

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -4,9 +4,14 @@ crumb :root do
 end
 
 crumb :user do
-  link "マイページ", users_path
+  link "マイページ", users_path(current_user)
+  parent :root
 end
 
+crumb :show do
+  link "商品詳細", item_path
+  parent :root
+end
 
 # crumb :projects do
 #   link "Projects", projects_path

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -3,11 +3,10 @@ crumb :root do
   link "トップページ", root_path
 end
 
-# マイページ
 crumb :user do
   link "マイページ", users_path
-  parent :root
 end
+
 
 # crumb :projects do
 #   link "Projects", projects_path


### PR DESCRIPTION
# What
パンくずリスト実装

# Why
ユーザーが今WEBサイト内のどの位置にいるのかを視覚的に分かりやすくするため、上位の階層となるWEBページを階層順にリストアップしてリンクを設置する

# 実際のビュー
https://gyazo.com/65316e68245b99d171585dfb7aead49b
https://gyazo.com/9a7e9fdc8c560ebfce1612f9ae973d8d